### PR TITLE
Critical vulnerability resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
           <groupId>org.seleniumhq.selenium</groupId>
           <artifactId>selenium-server</artifactId>
           <version>3.0.1</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.eclipse.jetty.websocket</groupId>
+              <artifactId>websocket-client</artifactId>
+            </exclusion>
+          </exclusions>
       </dependency>
       <dependency>
           <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
 		<artifactId>commons-cli</artifactId>
 		<version>1.2</version>
 	</dependency>
- <dependency>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                        <version>1.2.16</version>
-                </dependency>
+  <dependency>
+    <groupId>org.apache.logging.log4j</groupId>
+    <artifactId>log4j-core</artifactId>
+    <version>2.19.0</version>
+  </dependency>
 <dependency>
 	<groupId>edu.stanford.ejalbert</groupId>
 	<artifactId>BrowserLauncher2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,51 @@
     <defaultGoal>clean compile assembly:single</defaultGoal>
     <sourceDirectory>src/java</sourceDirectory>
     <finalName>epadd-standalone</finalName>
+
+    <pluginManagement>
+      <plugins>
+
+        <!-- mvn org.owasp:dependency-check-maven:check -->
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>7.3.0</version>
+          <configuration>
+            <format>html</format>
+            <outputDirectory>${project.basedir}/target</outputDirectory>
+
+            <!-- Unable to resolve system scoped dependency: jdk.tools:jdk.tools:jar:1.6:system -->
+            <skipSystemScope>true</skipSystemScope>
+
+            <!-- mvn org.owasp:dependency-check-maven:check -DpathToYarn="C:\Program Files\nodejs\yarn.cmd" -->
+            <!-- <pathToYarn>C:\Program Files\nodejs\yarn.cmd</pathToYarn> -->
+
+            <!-- <failBuildOnCVSS>0</failBuildOnCVSS> -->
+            <!-- <cveValidForHours>168</cveValidForHours> -->
+            <!-- <centralAnalyzerEnabled>false</centralAnalyzerEnabled> -->
+            <!-- <nexusAnalyzerEnabled>false</nexusAnalyzerEnabled> -->
+            <!-- <pyDistributionAnalyzerEnabled>false</pyDistributionAnalyzerEnabled> -->
+            <!-- <pyPackageAnalyzerEnabled>false</pyPackageAnalyzerEnabled> -->
+            <!-- <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled> -->
+            <!-- <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled> -->
+            <!-- <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled> -->
+            <!-- <composerAnalyzerEnabled>false</composerAnalyzerEnabled> -->
+            <!-- <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled> -->
+            <!-- <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled> -->
+            <!-- <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled> -->
+            <!-- <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled> -->
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>aggregate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
         <plugin>
            <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,14 @@
               <groupId>org.eclipse.jetty.websocket</groupId>
               <artifactId>websocket-client</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>org.seleniumhq.selenium</groupId>
+              <artifactId>jetty-repacked</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>netty</artifactId>
+            </exclusion>
           </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,10 @@
 	</dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
-    <artifactId>log4j-core</artifactId>
+    <artifactId>log4j-1.2-api</artifactId>
     <version>2.19.0</version>
-  </dependency>
+    <scope>provided</scope>
+</dependency>
 <dependency>
 	<groupId>edu.stanford.ejalbert</groupId>
 	<artifactId>BrowserLauncher2</artifactId>


### PR DESCRIPTION
This will require explicit maven action `mvn org.owasp:dependency-check-maven:check`.

Fast forward PR from GitHub independent vulnerability check using maven plugin.

Initial dependency tree.
```
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------< edu.stanford.epadd:epadd-standalone >-----------------
[INFO] Building ePADD-standalone 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ epadd-standalone ---
[WARNING] The artifact xml-apis:xml-apis:jar:2.0.2 has been relocated to xml-apis:xml-apis:jar:1.0.b2
[INFO] edu.stanford.epadd:epadd-standalone:jar:1.0-SNAPSHOT
[INFO] +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.65:compile
[INFO] |  \- org.apache.tomcat:tomcat-annotations-api:jar:9.0.65:compile
[INFO] +- org.apache.tomcat.embed:tomcat-embed-jasper:jar:9.0.65:compile
[INFO] |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:9.0.65:compile
[INFO] |  \- org.eclipse.jdt:ecj:jar:3.18.0:compile
[INFO] +- org.apache.tomcat:tomcat-jasper:jar:9.0.65:compile
[INFO] |  +- org.apache.tomcat:tomcat-servlet-api:jar:9.0.65:compile
[INFO] |  +- org.apache.tomcat:tomcat-juli:jar:9.0.65:compile
[INFO] |  +- org.apache.tomcat:tomcat-el-api:jar:9.0.65:compile
[INFO] |  +- org.apache.tomcat:tomcat-api:jar:9.0.65:compile
[INFO] |  \- org.apache.tomcat:tomcat-util-scan:jar:9.0.65:compile
[INFO] |     \- org.apache.tomcat:tomcat-util:jar:9.0.65:compile
[INFO] +- org.apache.tomcat:tomcat-jasper-el:jar:9.0.65:compile
[INFO] +- org.apache.tomcat:tomcat-jsp-api:jar:9.0.65:compile
[INFO] +- commons-cli:commons-cli:jar:1.2:compile
[INFO] +- log4j:log4j:jar:1.2.16:compile
[INFO] +- edu.stanford.ejalbert:BrowserLauncher2:jar:1.3:compile
[INFO] +- org.seleniumhq.selenium:selenium-server:jar:3.0.1:compile
[INFO] |  +- org.seleniumhq.selenium:selenium-java:jar:3.0.1:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-chrome-driver:jar:3.0.1:compile
[INFO] |  |  |  \- org.seleniumhq.selenium:selenium-remote-driver:jar:3.0.1:compile
[INFO] |  |  |     +- org.seleniumhq.selenium:selenium-api:jar:3.0.1:compile
[INFO] |  |  |     +- cglib:cglib-nodep:jar:3.2.4:compile
[INFO] |  |  |     +- org.apache.commons:commons-exec:jar:1.3:compile
[INFO] |  |  |     +- com.google.code.gson:gson:jar:2.3.1:compile
[INFO] |  |  |     +- com.google.guava:guava:jar:19.0:compile
[INFO] |  |  |     \- net.java.dev.jna:jna-platform:jar:4.1.0:compile
[INFO] |  |  |        \- net.java.dev.jna:jna:jar:4.1.0:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-edge-driver:jar:3.0.1:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-firefox-driver:jar:3.0.1:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-ie-driver:jar:3.0.1:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-opera-driver:jar:3.0.1:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-safari-driver:jar:3.0.1:compile
[INFO] |  |  |  \- io.netty:netty:jar:3.5.7.Final:compile
[INFO] |  |  +- org.seleniumhq.selenium:selenium-support:jar:3.0.1:compile
[INFO] |  |  +- net.sourceforge.htmlunit:htmlunit:jar:2.23:compile
[INFO] |  |  |  +- xalan:xalan:jar:2.7.2:compile
[INFO] |  |  |  |  \- xalan:serializer:jar:2.7.2:compile
[INFO] |  |  |  +- org.apache.commons:commons-lang3:jar:3.4:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
[INFO] |  |  |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpmime:jar:4.5.2:compile
[INFO] |  |  |  +- commons-codec:commons-codec:jar:1.10:compile
[INFO] |  |  |  +- net.sourceforge.htmlunit:htmlunit-core-js:jar:2.23:compile
[INFO] |  |  |  +- net.sourceforge.htmlunit:neko-htmlunit:jar:2.23:compile
[INFO] |  |  |  |  \- xerces:xercesImpl:jar:2.11.0:compile
[INFO] |  |  |  |     \- xml-apis:xml-apis:jar:1.4.01:compile
[INFO] |  |  |  +- net.sourceforge.cssparser:cssparser:jar:0.9.20:compile
[INFO] |  |  |  |  \- org.w3c.css:sac:jar:1.3:compile
[INFO] |  |  |  +- commons-io:commons-io:jar:2.5:compile
[INFO] |  |  |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  +- com.codeborne:phantomjsdriver:jar:1.3.0:compile
[INFO] |  |  \- org.eclipse.jetty.websocket:websocket-client:jar:9.2.15.v20160210:compile
[INFO] |  |     +- org.eclipse.jetty:jetty-util:jar:9.2.15.v20160210:compile
[INFO] |  |     +- org.eclipse.jetty:jetty-io:jar:9.2.15.v20160210:compile
[INFO] |  |     \- org.eclipse.jetty.websocket:websocket-common:jar:9.2.15.v20160210:compile
[INFO] |  |        \- org.eclipse.jetty.websocket:websocket-api:jar:9.2.15.v20160210:compile
[INFO] |  +- com.beust:jcommander:jar:1.48:compile
[INFO] |  +- net.jcip:jcip-annotations:jar:1.0:compile
[INFO] |  +- org.seleniumhq.selenium:jetty-repacked:jar:9.2.13.v20160825:compile
[INFO] |  |  \- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- org.seleniumhq.selenium:htmlunit-driver:jar:2.23:compile
[INFO] |  \- org.yaml:snakeyaml:jar:1.15:compile
[INFO] \- junit:junit:jar:4.11:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.373 s
[INFO] Finished at: 2022-11-28T15:50:33-06:00
[INFO] ------------------------------------------------------------------------
```
